### PR TITLE
removed error Use of undefined constant

### DIFF
--- a/src/josegonzalez/Queuesadilla/Worker/Base.php
+++ b/src/josegonzalez/Queuesadilla/Worker/Base.php
@@ -54,10 +54,10 @@ abstract class Base
         $this->logger->info("Shutting down");
 
         $signals = array(
-            SIGQUIT => "SIGQUIT",
-            SIGTERM => "SIGTERM",
-            SIGINT  => "SIGINT",
-            SIGUSR1 => "SIGUSR1",
+            'SIGQUIT' => "SIGQUIT",
+            'SIGTERM' => "SIGTERM",
+            'SIGINT'  => "SIGINT",
+            'SIGUSR1' => "SIGUSR1",
         );
 
         if ($signo !== null) {


### PR DESCRIPTION
When running worker. the below error was received. resolved the error by adding single quotes to it.

A PHP Error was encountered

Severity:    Notice
Message:     Use of undefined constant SIGQUIT - assumed 'SIGQUIT'
Filename:    /Users/kanhai/htdocs/rabbitmq/application/vendor/josegonzalez/queuesadilla/src/josegonzalez/Queuesadilla/Worker/Base.php
Line Number: 57

Backtrace:
	File: /Users/kanhai/htdocs/rabbitmq/application/vendor/josegonzalez/queuesadilla/src/josegonzalez/Queuesadilla/Worker/Base.php
	Line: 57
	Function: _error_handler



A PHP Error was encountered

Severity:    Notice
Message:     Use of undefined constant SIGTERM - assumed 'SIGTERM'
Filename:    /Users/kanhai/htdocs/rabbitmq/application/vendor/josegonzalez/queuesadilla/src/josegonzalez/Queuesadilla/Worker/Base.php
Line Number: 58

Backtrace:
	File: /Users/kanhai/htdocs/rabbitmq/application/vendor/josegonzalez/queuesadilla/src/josegonzalez/Queuesadilla/Worker/Base.php
	Line: 58
	Function: _error_handler



A PHP Error was encountered

Severity:    Notice
Message:     Use of undefined constant SIGINT - assumed 'SIGINT'
Filename:    /Users/kanhai/htdocs/rabbitmq/application/vendor/josegonzalez/queuesadilla/src/josegonzalez/Queuesadilla/Worker/Base.php
Line Number: 59

Backtrace:
	File: /Users/kanhai/htdocs/rabbitmq/application/vendor/josegonzalez/queuesadilla/src/josegonzalez/Queuesadilla/Worker/Base.php
	Line: 59
	Function: _error_handler



A PHP Error was encountered

Severity:    Notice
Message:     Use of undefined constant SIGUSR1 - assumed 'SIGUSR1'
Filename:    /Users/kanhai/htdocs/rabbitmq/application/vendor/josegonzalez/queuesadilla/src/josegonzalez/Queuesadilla/Worker/Base.php
Line Number: 60

Backtrace:
	File: /Users/kanhai/htdocs/rabbitmq/application/vendor/josegonzalez/queuesadilla/src/josegonzalez/Queuesadilla/Worker/Base.php
	Line: 60
	Function: _error_handler